### PR TITLE
add support for png screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,12 @@ var chrome = steer({
 
 chrome.once('open', function () {
 
-  // The second argument (60) is the JPEG quality
-  screenshot(chrome, 60, function (err, buffer, attemps) {
+  var options = {
+    format: 'png', // defaults to "jpeg", "png"|"jpeg"
+    quality: 100 // defaults to 100, 0 <= quality <= 100,
+  }
+
+  screenshot(chrome, options, function (err, buffer, attemps) {
     if (err) throw err;
     console.log('Screenshot taken after ' + attemps + ' attemps');
     fs.writeFileSync('picture.jpg', buffer);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "steer-screenshot",
   "description": "Take a screenshot of a google chrome window",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "Andreas Madsen <amwebdk@gmail.com>",
   "main": "./steer-screenshot.js",
   "scripts": {

--- a/steer-screenshot.js
+++ b/steer-screenshot.js
@@ -3,10 +3,46 @@ var gm = require('gm');
 var async = require('async');
 var endpoint = require('endpoint');
 
-module.exports = function screenshot(browser, quality, callback) {
+var defaults = {
+  format: 'jpeg',
+  quality: 100
+};
+
+module.exports = function screenshot(browser, options, callback) {
   var retryCount = 5;
   var currentAttempt = 1;
   var timeouts = [10, 100, 250, 500];
+
+  // default arguments
+  if (!options) {
+
+    options = defaults;
+
+  } else {
+
+    if (!options.format) {
+      options.format = defaults.format;
+    }
+
+    if (!options.quality) {
+      options.quality = defaults.quality;
+    }
+
+    // normalize format
+    if (options.format === 'jpg') {
+      options.format = 'jpeg';
+    }
+
+    // validate options
+    if (options.format !== 'jpeg' && options.format !== 'png') {
+      throw new TypeError('steer-screenshot only supports JPEG and PNG images');
+    }
+
+    if (typeof options.quality !== 'number') {
+      throw new TypeError('steer-screenshot\'s "quality" option expects a Number');
+    }
+
+  }
 
   // The error is never null in this function call
   function retry(err) {
@@ -23,7 +59,8 @@ module.exports = function screenshot(browser, quality, callback) {
 
   function attempt() {
     browser.extension.send('chrome.tabs.captureVisibleTab', null, {
-        'quality': quality
+        format: options.format,
+        quality: options.quality
     }, function(err, img) {
       if (err) return callback(err, null, currentAttempt);
 
@@ -35,7 +72,7 @@ module.exports = function screenshot(browser, quality, callback) {
       }
 
       // Validate base64 url prefix
-      var prefix = 'data:image/jpeg;base64,';
+      var prefix = 'data:image/' + options.format + ';base64,';
       var header = img.substring(0, prefix.length);
       if (header !== prefix) {
         err = new Error('Screenshot generated is not a data-url');
@@ -44,7 +81,7 @@ module.exports = function screenshot(browser, quality, callback) {
 
       // Validate that its a real image
       var buffer = new Buffer(img.slice(prefix.length), 'base64');
-      gm(buffer, 'validate.jpeg').stream(function(err, stdout, stderr) {
+      gm(buffer, 'validate.' + options.format).stream(function(err, stdout, stderr) {
         if (err) return callback(err, null, currentAttempt);
 
         async.parallel({

--- a/test/browser/screenshot.js
+++ b/test/browser/screenshot.js
@@ -26,6 +26,40 @@ server.listen(0, function() {
   var chrome = browser({ size: [800, 600], permissions: ['tabs'] }, function() {
     var originalExtensionSend = chrome.extension.send;
 
+    test('options are validated', function(t) {
+
+      t.test('format is validated', function(t) {
+
+        var _err = null;
+
+        try {
+          screenshot(chrome, { format: 'gif' }, function (){});
+        } catch (err) {
+          _err = err;
+        } finally {
+          t.equal(_err instanceof TypeError, true);
+          t.end();
+        }
+
+      });
+
+      t.test('quality is validated', function(t) {
+
+        var _err = null;
+
+        try {
+          screenshot(chrome, { quality: 'foo' }, function (){});
+        } catch (err) {
+          _err = err;
+        } finally {
+          t.equal(_err instanceof TypeError, true);
+          t.end();
+        }
+
+      });
+
+    });
+
     test('taking screenshot outputs a base64 data url string', function(t) {
       router.get('/test', function() {
         var res = this.res;
@@ -39,26 +73,79 @@ server.listen(0, function() {
         //TODO: find some event there can do this
         setTimeout(function() {
 
-          screenshot(chrome, 60, function(err, buffer, attempts) {
-            t.equal(err, null);
-            t.equal(attempts, 1);
+          t.test('format is jpeg', function (t) {
 
-            // Check the buffer size as a form of validation
-            t.ok(buffer.length >= 3 * 1024, 'image is min 3 KB');
-            t.ok(buffer.length <= 4 * 1024, 'image is max 4 KB');
+            screenshot(chrome, { quality: 60 }, function(err, buffer, attempts) {
+              t.equal(err, null);
+              t.equal(attempts, 1);
 
-            // Test the image size should be: 800 x 600
-            gm(buffer, 'validate.jpeg').size(function(err, value) {
-              t.equal(err || null, null); // gm is a bad citizen
+              // Check the buffer size as a form of validation
+              t.ok(buffer.length >= 3 * 1024, 'image is min 3 KB');
+              t.ok(buffer.length <= 4 * 1024, 'image is max 4 KB');
 
-              t.deepEqual(value, {
-                width: 800,
-                height: 600
+              gm(buffer, 'validate.jpeg')
+
+              // Test the image format is JPEG
+              .format(function(err, value) {
+
+                t.equal(err || null, null);
+                t.equal(value, 'JPEG');
+
+              })
+
+              // Test the image size should be: 800 x 600
+              .size(function(err, value) {
+                t.equal(err || null, null); // gm is a bad citizen
+
+                t.deepEqual(value, {
+                  width: 800,
+                  height: 600
+                });
+
+                t.end();
               });
-
-              t.end();
             });
+
           });
+
+          t.test('format is png', function (t) {
+
+            screenshot(chrome, { format: 'png', quality: 60 }, function(err, buffer, attempts) {
+
+              console.log('ERROR', err)
+
+              t.equal(err, null);
+              t.equal(attempts, 1);
+
+              // Check the buffer size as a form of validation
+              t.ok(buffer.length >= 3 * 1024, 'image is min 3 KB');
+              t.ok(buffer.length <= 4 * 1024, 'image is max 4 KB');
+
+              gm(buffer, 'validate.png')
+
+              // Test the image format is PNG
+              .format(function(err, value) {
+
+                t.equal(err || null, null);
+                t.equal(value, 'PNG');
+
+              })
+
+              // Test the image size should be: 800 x 600
+              .size(function(err, value) {
+                t.equal(err || null, null); // gm is a bad citizen
+
+                t.deepEqual(value, {
+                  width: 800,
+                  height: 600
+                });
+
+                t.end();
+              });
+            });
+
+          });
+
         }, 100);
       });
     });
@@ -71,7 +158,7 @@ server.listen(0, function() {
         callback(null, 'InvalidDataURL');
       };
 
-      screenshot(chrome, 60, function(err, result, attempts) {
+      screenshot(chrome, { quality: 60 }, function(err, result, attempts) {
         // Restore extension.send
         chrome.extension.send = originalExtensionSend;
 
@@ -93,7 +180,7 @@ server.listen(0, function() {
         callback(null, undefined);
       };
 
-      screenshot(chrome, 60, function(err, result, attempts) {
+      screenshot(chrome, { quality: 60 }, function(err, result, attempts) {
         // Restore extension.send
         chrome.extension.send = originalExtensionSend;
 
@@ -118,7 +205,7 @@ server.listen(0, function() {
 
       var msg = 'gm convert: No decode delegate for this image format';
 
-      screenshot(chrome, 60, function(err, result, attempts) {
+      screenshot(chrome, { quality: 60 }, function(err, result, attempts) {
         // Restore extension.send
         chrome.extension.send = originalExtensionSend;
 


### PR DESCRIPTION
png seems to produce better quality images.

note that this is a breaking change, because the module api changes:

``` js
// before:
screenshot(chrome, Number, callback)

// after:
screenshot(chrome, { quality: Number, format: String }, callback)
```

jpg@100:
![svgs-to-fonts-demo-spec](https://cloud.githubusercontent.com/assets/1761758/5563065/160ceebc-8e09-11e4-8333-ca3e8e3159c2.jpg)

png@100:
![svgs-to-fonts-demo-spec](https://cloud.githubusercontent.com/assets/1761758/5563066/161287b4-8e09-11e4-93ee-84d160c45027.png)
